### PR TITLE
Add tiling support to tiff write

### DIFF
--- a/imagecore/formats/internal/tiff.h
+++ b/imagecore/formats/internal/tiff.h
@@ -70,6 +70,18 @@ public:
 
 	virtual bool copyLossless(ImageReader* reader);
 
+	enum SupportedWriteOptions
+	{
+		// Default to tiled mode, this option forces progressive (scanline) based encoding
+		kSupportedWriteOptions_Progressive       = 0x200,
+
+		// Tile size, bounded to [16..256] inclusive, 0 denotes auto choose based on resolution
+		kSupportedWriteOptions_TIFFTileSizeMask  = 0x1FF0000,
+	};
+	static_assert(sizeof(SupportedWriteOptions) == sizeof(unsigned int), "Cannot mask unsigned int write options, incompatible sizes.");
+
+	virtual void setWriteOptions(unsigned int writeOptions);
+
 	enum SeekMode
 	{
 		kSeek_Set = 0,
@@ -108,6 +120,8 @@ private:
 	SeekableMemoryStorage *m_TempStorage;
 	Storage *m_OutputStorage;
 	uint8_t *m_EncodedDataBuffer;
+	unsigned int m_WriteOptions;
+	unsigned int m_TileSize;
 };
 
 }

--- a/imagecore/formats/writer.h
+++ b/imagecore/formats/writer.h
@@ -122,7 +122,8 @@ public:
 		kWriteOption_AssumeMCUPaddingFilled     = 0x80,
 		kWriteOption_ForcePNGRunLengthEncoding  = 0x100,
 		kWriteOption_Progressive                = 0x200,
-		kWriteOption_ForceNoChromaSubsampling   = 0x300
+		kWriteOption_ForceNoChromaSubsampling   = 0x400,
+		kWriteOption_TIFFTileSizeMask           = 0x1FF0000
 	};
 
 	virtual ~ImageWriter() { }


### PR DESCRIPTION
Enabled by default.
Value of 0 (not set) auto chooses largest possible square tiles that aligns evenly to the resolution.
Tile sizes of [16..256] supported (512 may work if cap is removed). Only supports aligned tile sizes, no partial tiles on the right or bottom edges.
Tiling can be disabled with Progressive flag (cross-used for progressive JPEG).  Even though the meaning of 'Progressive' is different, the terminology works well enough for this case too.
Fix small bug in force no chroma subsampling leading to progressive JPEGs accidentally being created and undesirable effects to PNG if used in that context.